### PR TITLE
Workspace names can only include underscores

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ module "random_id" {
 }
 
 locals {
-  workspace_name = "${module.random_pet.random_pet}-${module.random_id.random_id}"
+  workspace_name = "${module.random_pet.random_pet}_${module.random_id.random_id}"
 }
 
 resource "tfe_workspace" "this" {


### PR DESCRIPTION
- Commit to development
- added submodule for tf-variables
- Removed un-needed variables from root module and set var type for workspace_variable as bool
- Added module parameter variables
- Added outputs
- Created variables for organization name
- Added random_id and random_pet
- Separated tags to include random_pet and random_id
- Workspace names can only include underscores
