### PR TITLE
Customer name variable ended with a period

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable "category" {
 variable "customer_name" {
   description = "POC customer name"
   type        = string
-  default     = "Acme Co."
+  default     = "Acme Co"
 }
 
 variable "description" {


### PR DESCRIPTION
- Commit to development
- added submodule for tf-variables
- Removed un-needed variables from root module and set var type for workspace_variable as bool
- Added module parameter variables
- Added outputs
- Created variables for organization name
- Added random_id and random_pet
- Separated tags to include random_pet and random_id
- Workspace names can only include underscores
- Default value for customer_name variable ended with a period
