### PR TITLE
VCS driven plans

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,10 +23,27 @@ locals {
   customer_name = lower(replace("${var.customer_name}", " ", "_"))
 }
 
+resource "tfe_oauth_client" "this" {
+  name                = var.tfe_oauth_client_name
+  organization        = var.organization
+  api_url             = var.api_url
+  http_url            = var.http_url
+  oauth_token         = var.oauth_token
+  service_provider    = var.service_provider
+}
+
 resource "tfe_workspace" "this" {
-  name  = local.workspace_name
-  organization =  var.organization
-  execution_mode = "remote"
+  name                = local.workspace_name
+  organization        = var.organization
+  execution_mode      = "remote"
+  allow_destroy_plan  = true
+  auto_apply          = true
+  working_directory   = var.working_directory
+  vcs_repo {
+    identifier        = var.vcs_repository
+    branch            = var.vcs_branch
+    oauth_token_id    = tfe_oauth_client.this.id
+  }
   tag_names = [
     "${local.customer_name}",
     "${module.random_pet.random_pet}",

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,8 @@
 # Remote State Bootstrap Module -- variables.tf
+variable "api_url" {
+  description = "API URL of the Version Control Provider"
+  type        = string
+}
 
 variable "category" {
   description = "Whether this is a Terraform or environment variable. Available options: terraform or env"
@@ -9,7 +13,6 @@ variable "category" {
 variable "customer_name" {
   description = "POC customer name"
   type        = string
-  default     = "Acme Co"
 }
 
 variable "description" {
@@ -30,6 +33,16 @@ variable "hcl" {
   default     = false
 }
 
+variable "http_url" {
+  description = "HTTP URL of the VCS provider"
+  type        = string
+}
+
+variable "oauth_token" {
+  description = "OAuth Token String provided by the VCS provider"
+  type        = string
+}
+
 variable "organization" {
   description = "Terraform Cloud organization which has the backend state-file"
   type        = string
@@ -41,10 +54,20 @@ variable "sensitive" {
   default     = false
 }
 
+variable "tfe_oauth_client_name" {
+  description = "Display name of the OAuth Client"
+  type        = string
+}
+
 variable "variable_set_variable" {
   description = "Whether this variable should be added to a variable set"
   type        = bool
   default     = true
+}
+
+variable "working_directory" {
+  description = "Working directory of the VCS repository from which TF plans are run"
+  type        = string
 }
 
 variable "workspace" {


### PR DESCRIPTION
- Commit to development
- added submodule for tf-variables
- Removed un-needed variables from root module and set var type for workspace_variable as bool
- Added module parameter variables
- Added outputs
- Created variables for organization name
- Added random_id and random_pet
- Separated tags to include random_pet and random_id
- Workspace names can only include underscores
- Default value for customer_name variable ended with a period
- Forgot to convert customer name variable into lower-case and replace spaces with underscores. Fixed by defining a local variable.
- Adding resource for tfe_oauth_client for VCS driven plans.
