### PR TITLE
OAuth Client + VCS Add Bool variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,15 +23,6 @@ locals {
   customer_name = lower(replace("${var.customer_name}", " ", "_"))
 }
 
-resource "tfe_oauth_client" "this" {
-  name                = var.tfe_oauth_client_name
-  organization        = var.organization
-  api_url             = var.api_url
-  http_url            = var.http_url
-  oauth_token         = var.oauth_token
-  service_provider    = var.service_provider
-}
-
 resource "tfe_workspace" "this" {
   name                = local.workspace_name
   organization        = var.organization
@@ -40,6 +31,7 @@ resource "tfe_workspace" "this" {
   auto_apply          = true
   working_directory   = var.working_directory
   vcs_repo {
+    count             = var.add_vcs_repo ? 0 : 1
     identifier        = var.vcs_repository
     branch            = var.vcs_branch
     oauth_token_id    = tfe_oauth_client.this.id

--- a/modules/tfe_oauth_client/main.tf
+++ b/modules/tfe_oauth_client/main.tf
@@ -1,0 +1,10 @@
+# tfe_oauth_client sub-module -- main.tf
+
+resource "tfe_oauth_client" "this" {
+  name                = var.tfe_oauth_client_name
+  organization        = var.organization
+  api_url             = var.api_url
+  http_url            = var.http_url
+  oauth_token         = var.oauth_token
+  service_provider    = var.service_provider
+}

--- a/modules/tfe_oauth_client/variables.tf
+++ b/modules/tfe_oauth_client/variables.tf
@@ -1,0 +1,34 @@
+# tfe_oauth_client sub-module -- variables.tf
+variable "api_url" {
+  description = "API URL of the Version Control Provider"
+  type        = string
+}
+
+variable "http_url" {
+  description = "HTTP URL of the VCS provider"
+  type        = string
+}
+
+variable "oauth_token" {
+  description = "OAuth Token String provided by the VCS provider"
+  type        = string
+  sensitive   = true
+}
+
+variable "organization" {
+  description = "Terraform Cloud organization which has the backend state-file"
+  type        = string
+}
+
+variable "service_provider" {
+  description = "VCS provider being connected with"
+  type        = string
+  default     = "github"
+}
+
+variable "tfe_oauth_client_name" {
+  description = "Display name of the OAuth Client"
+  type        = string
+}
+
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,8 @@
 # Remote State Bootstrap Module -- variables.tf
-variable "api_url" {
-  description = "API URL of the Version Control Provider"
-  type        = string
+variable "add_vcs_repo" {
+  description = "Whether or not to add a VCS repo to this workspace"
+  type        = bool
+  default     = false
 }
 
 variable "category" {
@@ -33,16 +34,6 @@ variable "hcl" {
   default     = false
 }
 
-variable "http_url" {
-  description = "HTTP URL of the VCS provider"
-  type        = string
-}
-
-variable "oauth_token" {
-  description = "OAuth Token String provided by the VCS provider"
-  type        = string
-}
-
 variable "organization" {
   description = "Terraform Cloud organization which has the backend state-file"
   type        = string
@@ -52,11 +43,6 @@ variable "sensitive" {
   description = "Whether the variable value is sensitive"
   type        = bool
   default     = false
-}
-
-variable "tfe_oauth_client_name" {
-  description = "Display name of the OAuth Client"
-  type        = string
 }
 
 variable "variable_set_variable" {


### PR DESCRIPTION
- Commit to development
- added submodule for tf-variables
- Removed un-needed variables from root module and set var type for workspace_variable as bool
- Added module parameter variables
- Added outputs
- Created variables for organization name
- Added random_id and random_pet
- Separated tags to include random_pet and random_id
- Workspace names can only include underscores
- Default value for customer_name variable ended with a period
- Forgot to convert customer name variable into lower-case and replace spaces with underscores. Fixed by defining a local variable.
- Adding resource for tfe_oauth_client for VCS driven plans.
- Created submodule for tfe OAUth client and added a bool value to add VCS if bool is true
