### PR TITLE
Default value for working directory

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,7 @@ variable "variable_set_variable" {
 variable "working_directory" {
   description = "Working directory of the VCS repository from which TF plans are run"
   type        = string
+  default     = ""
 }
 
 variable "workspace" {


### PR DESCRIPTION
- Commit to development
- added submodule for tf-variables
- Removed un-needed variables from root module and set var type for workspace_variable as bool
- Added module parameter variables
- Added outputs
- Created variables for organization name
- Added random_id and random_pet
- Separated tags to include random_pet and random_id
- Workspace names can only include underscores
- Default value for customer_name variable ended with a period
- Forgot to convert customer name variable into lower-case and replace spaces with underscores. Fixed by defining a local variable.
- Adding resource for tfe_oauth_client for VCS driven plans.
- Created submodule for tfe OAUth client and added a bool value to add VCS if bool is true
- Set default value for working directory
