### PR TITLE
Dynamic block for VCS repo

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,12 +30,15 @@ resource "tfe_workspace" "this" {
   allow_destroy_plan  = true
   auto_apply          = true
   working_directory   = var.working_directory
-  vcs_repo {
-    count             = var.add_vcs_repo ? 0 : 1
-    identifier        = var.vcs_repository
-    branch            = var.vcs_branch
-    oauth_token_id    = tfe_oauth_client.this.id
+  dynamic "vcs_repo" {
+    for_each = var.add_vcs_repo == true ? [true] : []
+    content {
+      identifier        = var.vcs_repository
+      branch            = var.vcs_branch
+      oauth_token_id    = tfe_oauth_client.this.id
+    }
   }
+
   tag_names = [
     "${local.customer_name}",
     "${module.random_pet.random_pet}",


### PR DESCRIPTION
- Commit to development
- added submodule for tf-variables
- Removed un-needed variables from root module and set var type for workspace_variable as bool
- Added module parameter variables
- Added outputs
- Created variables for organization name
- Added random_id and random_pet
- Separated tags to include random_pet and random_id
- Workspace names can only include underscores
- Default value for customer_name variable ended with a period
- Forgot to convert customer name variable into lower-case and replace spaces with underscores. Fixed by defining a local variable.
- Adding resource for tfe_oauth_client for VCS driven plans.
- Created submodule for tfe OAUth client and added a bool value to add VCS if bool is true
- Set default value for working directory
- Added dynamic block for vcs_repo
