### PR TITLE
Added variables for vcs_repo dynamic block

### DIFF
--- a/modules/tfe_oauth_client/main.tf
+++ b/modules/tfe_oauth_client/main.tf
@@ -4,7 +4,7 @@ resource "tfe_oauth_client" "this" {
   name                = var.tfe_oauth_client_name
   organization        = var.organization
   api_url             = var.api_url
-  http_url            = var.http_url
+  http_url            = var.https_url
   oauth_token         = var.oauth_token
   service_provider    = var.service_provider
 }

--- a/modules/tfe_oauth_client/variables.tf
+++ b/modules/tfe_oauth_client/variables.tf
@@ -4,7 +4,7 @@ variable "api_url" {
   type        = string
 }
 
-variable "http_url" {
+variable "https_url" {
   description = "HTTP URL of the VCS provider"
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,12 @@ variable "add_vcs_repo" {
   default     = false
 }
 
+variable "vcs_branch" {
+  description = "Branch of the VCS Repository to add. Default is 'main'"
+  type        = string
+  default     = "main"
+}
+
 variable "category" {
   description = "Whether this is a Terraform or environment variable. Available options: terraform or env"
   type        = string
@@ -49,6 +55,12 @@ variable "variable_set_variable" {
   description = "Whether this variable should be added to a variable set"
   type        = bool
   default     = true
+}
+
+variable "vcs_repository" {
+  description = "The VCS Repository to add to the workspace"
+  type        = string
+  default     = ""
 }
 
 variable "working_directory" {


### PR DESCRIPTION
- Commit to development
- added submodule for tf-variables
- Removed un-needed variables from root module and set var type for workspace_variable as bool
- Added module parameter variables
- Added outputs
- Created variables for organization name
- Added random_id and random_pet
- Separated tags to include random_pet and random_id
- Workspace names can only include underscores
- Default value for customer_name variable ended with a period
- Forgot to convert customer name variable into lower-case and replace spaces with underscores. Fixed by defining a local variable.
- Adding resource for tfe_oauth_client for VCS driven plans.
- Created submodule for tfe OAUth client and added a bool value to add VCS if bool is true
- Set default value for working directory
- Added dynamic block for vcs_repo
- Added output for oauth client id
- Added variables for vcs_repo dynamic block
