### PR TITLE
set variables to workspace

### DIFF
--- a/modules/tfe_variables/main.tf
+++ b/modules/tfe_variables/main.tf
@@ -7,17 +7,5 @@ resource "tfe_variable" "this" {
   category        = var.category
   sensitive       = var.sensitive
   hcl             = var.hcl
-  dynamic "variable_set_id" {
-    count = var.variable_set ? [1] : []
-    content {
-      variable_set_id = var.variable_set_id
-    }
-  }
-
-  dynamic "workspace_id" {
-    count = var.variable_set ? [] : [1]
-    content {
-      workspace_id = var.workspace_id
-    }
-  }
+  workspace_ids   = var.workspace_id
 }

--- a/modules/tfe_variables/variables.tf
+++ b/modules/tfe_variables/variables.tf
@@ -58,22 +58,7 @@ variable "variable_set" {
   default     = true
 }
 
-variable "variable_set_id" {
-  description = "Variable Set ID for the variable set"
-  type        = string
-  default     = ""
-  validation {
-    condition = var.variable_set_id != ""
-    error_message = "If variable_set is true, variable set ID must be provided."
-  }
-}
-
 variable "workspace_id" {
   description = "Workspace ID for the variable"
   type        = string
-  default     = ""
-  validation {
-    condition = var.workspace_id != ""
-    error_message = "If variable_set is false, workspace ID must be provided."
-  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,6 +14,6 @@ output "random_id" {
   value = module.random_id.random_id
 }
 
-output "variable_set_id" {
-  value = tfe_variable_set.this.id
+output "workspace_id" {
+  value = tfe_workspace.this.id
 }


### PR DESCRIPTION
- Commit to development
- added submodule for tf-variables
- Removed un-needed variables from root module and set var type for workspace_variable as bool
- Added module parameter variables
- Added outputs
- Created variables for organization name
- Added random_id and random_pet
- Separated tags to include random_pet and random_id
- Workspace names can only include underscores
- Default value for customer_name variable ended with a period
- Forgot to convert customer name variable into lower-case and replace spaces with underscores. Fixed by defining a local variable.
- Adding resource for tfe_oauth_client for VCS driven plans.
- Created submodule for tfe OAUth client and added a bool value to add VCS if bool is true
- Set default value for working directory
- Added dynamic block for vcs_repo
- Added output for oauth client id
- Added variables for vcs_repo dynamic block
- add variable for oauth token id
- Added default value for oauth_token_id
- Removed default value from oauth_token_id variable and added dynamic logic to add_vcs_repo == false
- re-added default value for oauth_token_id
- removed default values fromv vcs and oauth token vars
- modifying dynamic block
- Added validation to required variables
- testing validation rule
- Added auto_apply and allow_destroy variables
- re-worked logic for variable module
- Added variable set id output value
- added workspace_id and variable_set_id vars + validatin
- Missing punctuation from validation error message
- Changed create_variable
- changed dynamic to count
- removed variable_set_id and set variables to workspace
